### PR TITLE
added pluggable key creation strategy: support for compound keys and prefix

### DIFF
--- a/src/jvm/trident/memcached/ConcatKeyBuilder.java
+++ b/src/jvm/trident/memcached/ConcatKeyBuilder.java
@@ -1,0 +1,56 @@
+package trident.memcached;
+
+import java.util.List;
+
+
+/**
+ * Basic {@link IStateSingleKeyBuilder} that just concatenates parts of a compound key into a string 
+ *
+ */
+public class ConcatKeyBuilder implements IStateSingleKeyBuilder {
+
+	private static final long serialVersionUID = 1L;
+	
+	// prefix assigned to each key => use this to keep key distinct if several parts of the topology write to the same memcached 
+	private final String prefix;		
+	
+	private final String nullKey;
+	private final String sep ;
+	
+	public ConcatKeyBuilder() {
+		this("");
+	}
+	public ConcatKeyBuilder(String prefix) {
+		this(prefix, "_");
+	}
+	public ConcatKeyBuilder(String prefix, String sep) {
+		this (prefix, sep, "nullkey");
+	}
+	
+	public ConcatKeyBuilder(String prefix, String sep, String nullKey) {
+		if (prefix == null) {
+			this.prefix = "";
+		} else if ("".equals(prefix)) {
+			this.prefix = "";
+		} else {
+			this.prefix = prefix + sep;
+		}
+		this.nullKey = nullKey;
+		this.sep = sep;
+	}
+	
+	@Override
+	public String buildSingleKey(List<Object> key) {
+		
+		if (key == null || key.isEmpty()) {
+			return nullKey;
+		} else {
+			StringBuffer sb = new StringBuffer(prefix);
+			for (Object o: key) {
+				sb.append(o).append(sep);
+			}
+			return sb.toString();
+		}
+	}
+
+}

--- a/src/jvm/trident/memcached/IStateSingleKeyBuilder.java
+++ b/src/jvm/trident/memcached/IStateSingleKeyBuilder.java
@@ -1,0 +1,13 @@
+package trident.memcached;
+
+import java.io.Serializable;
+import java.util.List;
+
+public interface IStateSingleKeyBuilder extends Serializable{
+
+	/**
+	 * @return a single field primary key from this compound key
+	 */
+	public String buildSingleKey(List<Object> key) ;
+	
+}

--- a/src/jvm/trident/memcached/MemcachedState.java
+++ b/src/jvm/trident/memcached/MemcachedState.java
@@ -79,7 +79,7 @@ public class MemcachedState<T> implements IBackingMap<T> {
     }
 
     public static StateFactory opaque(List<InetSocketAddress> servers, Options<OpaqueValue> opts) {
-    	return opaque(servers, opts);
+    	return new Factory(servers, StateType.OPAQUE, opts);
     }
 
     public static StateFactory transactional(List<InetSocketAddress> servers) {

--- a/src/jvm/trident/memcached/Test.java
+++ b/src/jvm/trident/memcached/Test.java
@@ -89,7 +89,7 @@ public class Test {
     	}
     }
     
-    public static StormTopology buildTopology(LocalDRPC drcp,  int memcachedPort) {
+    public static StormTopology buildTopology(LocalDRPC drpc,  int memcachedPort) {
     	
     	////////////////
     	// infinite source of words
@@ -123,7 +123,7 @@ public class Test {
                 .persistentAggregate(memcachedWords, new Count(), new Fields("count"))    
                 .parallelismHint(6);        
                 
-        topology.newDRPCStream("words", drcp)
+        topology.newDRPCStream("words", drpc)
                 .each(new Fields("args"), new Split(), new Fields("word"))
                 .groupBy(new Fields("word"))
                 .stateQuery(wordCounts, new Fields("word"), new MapGet(), new Fields("wordCount"))
@@ -145,14 +145,12 @@ public class Test {
         		.persistentAggregate(memcachedInitials, new Count(), new Fields("initCount"))         
         		.parallelismHint(6);
         
-        topology.newDRPCStream("1rstLetter", drcp)
+        topology.newDRPCStream("1rstLetter", drpc)
         		.each(new Fields("args"), new ParseCli(), new Fields("firstLetter", "length"))
         		.groupBy(new Fields("firstLetter", "length"))
                 .stateQuery(initialCounts, new Fields("firstLetter", "length"), new MapGet(), new Fields("initCount"))
                 .project(new Fields("firstLetter", "length", "initCount"))
                 ;
-        
-        
         
         return topology.build();
     }
@@ -172,7 +170,6 @@ public class Test {
         for(int i=0; i<100; i++) {
             System.out.println("DRPC: number of instances of 'cat', 'the', 'man' or 'four' counted so far: " + wordsDrpc.execute("words", "cat the man four"));
             System.out.println("DRPC: number of instances of 3-letter word starting with 't' or 6-letter word starting with 'a': " + wordsDrpc.execute("1rstLetter", "t 3, a 6"));
-            
             Utils.sleep(1000);
         }
         

--- a/src/jvm/trident/memcached/Test.java
+++ b/src/jvm/trident/memcached/Test.java
@@ -15,6 +15,8 @@ import com.thimbleware.jmemcached.storage.CacheStorage;
 import com.thimbleware.jmemcached.storage.hash.ConcurrentLinkedHashMap;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
+
+import storm.trident.Stream;
 import storm.trident.TridentState;
 import storm.trident.TridentTopology;
 import storm.trident.operation.BaseFunction;
@@ -26,6 +28,7 @@ import storm.trident.operation.builtin.Sum;
 import storm.trident.state.StateFactory;
 import storm.trident.testing.FixedBatchSpout;
 import storm.trident.tuple.TridentTuple;
+import trident.memcached.MemcachedState.Options;
 
 
 public class Test {
@@ -42,7 +45,11 @@ public class Test {
         daemon.start();
     }
 
-     public static class Split extends BaseFunction {
+     /**
+      * splits a space-separated sentence into words
+     *
+     */
+    public static class Split extends BaseFunction {
         @Override
         public void execute(TridentTuple tuple, TridentCollector collector) {
             String sentence = tuple.getString(0);
@@ -51,8 +58,42 @@ public class Test {
             }
         }
     }
+     
+     /**
+      * Emit the first letter and the lenght of each word longer than 2 letters
+     *
+     */
+    public static class Initial extends BaseFunction {
+    	@Override
+    	 public void execute(TridentTuple tuple, TridentCollector collector) {
+    		 String word = tuple.getString(0);
+			 if (word.length() > 2) {
+				 collector.emit(new Values(word.substring(0, 1), word.length()));                
+			 }
+    	 }
+     }
     
-    public static StormTopology buildTopology(LocalDRPC drpc, StateFactory state) {
+    /**
+     * expects a comma-separated queries like "t 3, a 6" and emit tuples like ('t', 3), ('a', 6)
+     *
+     */
+    public static class ParseCli extends BaseFunction {
+    	@Override
+    	public void execute(TridentTuple tuple, TridentCollector collector) {
+    		String queries = tuple.getString(0);
+    		for(String query: queries.split(",")) {
+    			String[] splitted = query.trim().split(" ");
+    			collector.emit(new Values(splitted[0].trim(), splitted[1].trim()));
+    		}
+    		
+    	}
+    }
+    
+    public static StormTopology buildTopology(LocalDRPC drcp,  int memcachedPort) {
+    	
+    	////////////////
+    	// infinite source of words
+    	
         FixedBatchSpout spout = new FixedBatchSpout(new Fields("sentence"), 3,
                 new Values("the cow jumped over the moon"),
                 new Values("the man went to the store and bought some candy"),
@@ -61,21 +102,57 @@ public class Test {
                 new Values("to be or not to be the person"));
         spout.setCycle(true);
         
+        
         TridentTopology topology = new TridentTopology();        
+        Stream words =              
+        		topology.newStream("spout1", spout)
+                .each(new Fields("sentence"), new Split(), new Fields("word"));
+ 
+        
+    	////////////////
+        // counting words + DRCP access to result
+       
+        
+        Options wordsOpt = new Options() ; 
+        wordsOpt.keyBuilder = new ConcatKeyBuilder("WORD_COUNT");
+        StateFactory memcachedWords = MemcachedState.nonTransactional(Arrays.asList(new InetSocketAddress("localhost", memcachedPort)), wordsOpt);
+        
         TridentState wordCounts =
-              topology.newStream("spout1", spout)
-                .each(new Fields("sentence"), new Split(), new Fields("word"))
+        		words
                 .groupBy(new Fields("word"))
-                .persistentAggregate(state, new Count(), new Fields("count"))         
-                .parallelismHint(6);
+                .persistentAggregate(memcachedWords, new Count(), new Fields("count"))    
+                .parallelismHint(6);        
                 
-        topology.newDRPCStream("words", drpc)
+        topology.newDRPCStream("words", drcp)
                 .each(new Fields("args"), new Split(), new Fields("word"))
                 .groupBy(new Fields("word"))
-                .stateQuery(wordCounts, new Fields("word"), new MapGet(), new Fields("count"))
-                .each(new Fields("count"), new FilterNull())
-                .aggregate(new Fields("count"), new Sum(), new Fields("sum"))
+                .stateQuery(wordCounts, new Fields("word"), new MapGet(), new Fields("wordCount"))
+                .each(new Fields("wordCount"), new FilterNull())
+                .aggregate(new Fields("wordCount"), new Sum(), new Fields("sum"))
                 ;
+        
+    	////////////////
+        // counting word having the same length and first letter + real-time DRCP access
+        
+        Options letterOpt = new Options();
+        letterOpt.keyBuilder = new ConcatKeyBuilder("INITAL_COUNT");
+        StateFactory memcachedInitials = MemcachedState.nonTransactional(Arrays.asList(new InetSocketAddress("localhost", memcachedPort)), letterOpt);
+
+        TridentState initialCounts =
+        		words
+        		.each(new Fields("word"), new Initial(), new Fields("firstLetter", "length"))
+        		.groupBy(new Fields("firstLetter", "length"))
+        		.persistentAggregate(memcachedInitials, new Count(), new Fields("initCount"))         
+        		.parallelismHint(6);
+        
+        topology.newDRPCStream("1rstLetter", drcp)
+        		.each(new Fields("args"), new ParseCli(), new Fields("firstLetter", "length"))
+        		.groupBy(new Fields("firstLetter", "length"))
+                .stateQuery(initialCounts, new Fields("firstLetter", "length"), new MapGet(), new Fields("initCount"))
+                .project(new Fields("firstLetter", "length", "initCount"))
+                ;
+        
+        
         
         return topology.build();
     }
@@ -85,16 +162,17 @@ public class Test {
     public static void main(String[] args) {
         int PORT = 10001;
         startLocalMemcacheInstance(PORT);
-        StateFactory memcached = MemcachedState.nonTransactional(Arrays.asList(new InetSocketAddress("localhost", PORT)));
         
-        LocalDRPC drpc = new LocalDRPC();
-        StormTopology topology = buildTopology(drpc, memcached);
+        LocalDRPC wordsDrpc = new LocalDRPC();
+        StormTopology topology = buildTopology(wordsDrpc,  PORT);
         Config conf = new Config();
         LocalCluster cluster = new LocalCluster();
         cluster.submitTopology("tester", conf, topology);
         
         for(int i=0; i<100; i++) {
-            System.out.println("DRPC: " + drpc.execute("words", "cat the man four"));
+            System.out.println("DRPC: number of instances of 'cat', 'the', 'man' or 'four' counted so far: " + wordsDrpc.execute("words", "cat the man four"));
+            System.out.println("DRPC: number of instances of 3-letter word starting with 't' or 6-letter word starting with 'a': " + wordsDrpc.execute("1rstLetter", "t 3, a 6"));
+            
             Utils.sleep(1000);
         }
         


### PR DESCRIPTION
Hi, 

The current version of the MemcachedState does not support compound keys. Also, if several parts of the topology save distinct states to memcached, the current implementation could lead to key overlap and thus destruction of state information. For example, a count grouping/saving by word running simultaneously to a count grouping/saving by first letter of the word could both yield key overlap for one-letter words like "a" in English or "y" in French. 

I added a mechanism that delegates to a IStateSingleKeyBuilder to make the creation of memcached key more flexible. I also added a default ConcatKeyBuilder implementation of IStateSingleKeyBuilder, which just concatenates the toString() of the compound key to solve issue 1 and allows a optional prefix to be configured to solve issue 2.

The new usage is backward compatible with the old syntax. I illustrate the new features in the updated example in Test.java. 

Unfortunately, I had to de-activate usage of CachedMap to have this working: data with compound keys put in the CachedMap by the example topology are never retrieved. I failed to understand why and failed to reproduce a bug with junit in CachedMap with compound keys. Simply commenting out CachedMap from MemcachedState solved the issue. 
